### PR TITLE
feat: default font size on each paltform

### DIFF
--- a/src/app/TheoIDE/Persistence/CMakeLists.txt
+++ b/src/app/TheoIDE/Persistence/CMakeLists.txt
@@ -12,6 +12,13 @@ qt_add_qml_module(
     URI TheoIDE.Persistence
     VERSION 1.0
     QML_FILES ${QML_FILE_SINGLETONS}
+    SOURCES
+        systemfontconfiguration.cpp include/systemfontconfiguration.hpp
+)
+
+target_include_directories(
+    TheoIDEPersistence
+    PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include/
 )
 
 target_link_libraries(

--- a/src/app/TheoIDE/Persistence/ThemeSettings.qml
+++ b/src/app/TheoIDE/Persistence/ThemeSettings.qml
@@ -3,6 +3,7 @@ pragma Singleton
 import QtCore
 import QtQuick
 import QtQuick.Controls.Material
+import TheoIDE.Persistence
 
 Settings {
     category: "Theme"
@@ -14,10 +15,10 @@ Settings {
     property color backgroundLight: "#fbf1c7"
     property color foregroundLight: "#3c3836"
     property color primaryLight: "#ebdbb2"
-    property int uiFontSize: 9
-    property int editorFontSize: 9
+    property int uiFontSize: SystemFontConfiguraton.defaultFontSize
+    property int editorFontSize: SystemFontConfiguraton.defaultMonospaceFontSize
     property int theme: Material.System
-    property string editorFontFamily: "monospace"
+    property string editorFontFamily: SystemFontConfiguraton.defaultMonospaceFont.family
     readonly property color accent: Material.theme === Material.Dark ? accentDark : accentLight
     readonly property color background: Material.theme === Material.Dark ? backgroundDark : backgroundLight
     readonly property color foreground: Material.theme === Material.Dark ? foregroundDark : foregroundLight

--- a/src/app/TheoIDE/Persistence/include/systemfontconfiguration.hpp
+++ b/src/app/TheoIDE/Persistence/include/systemfontconfiguration.hpp
@@ -1,0 +1,35 @@
+#ifndef _THEOIDE_PERSISTENCE_SYSTEMFONTCONFIGURATION_
+#define _THEOIDE_PERSISTENCE_SYSTEMFONTCONFIGURATION_
+
+#include <QtQml/qqmlregistration.h>
+#include <qfont.h>
+#include <qobject.h>
+#include <qobjectdefs.h>
+#include <qtmetamacros.h>
+
+class SystemFontConfiguraton : public QObject {
+  Q_OBJECT
+  QML_ELEMENT
+  QML_SINGLETON
+  Q_PROPERTY(int defaultFontSize READ defaultFontSize NOTIFY
+                 defaultFontSizeChanged FINAL)
+  Q_PROPERTY(int defaultMonospaceFontSize READ defaultMonospaceFontSize NOTIFY
+                 defaultMonospaceFontSizeChanged FINAL)
+  Q_PROPERTY(QFont defaultFont READ defaultFont NOTIFY defaultFontChanged FINAL)
+  Q_PROPERTY(QFont defaultMonospaceFont READ defaultMonospaceFont NOTIFY
+                 defaultMonospaceFontChanged FINAL)
+ public:
+  SystemFontConfiguraton(QObject* parent = nullptr);
+  ~SystemFontConfiguraton();
+  QFont defaultFont() const;
+  int defaultFontSize() const;
+  QFont defaultMonospaceFont() const;
+  int defaultMonospaceFontSize() const;
+ signals:
+  void defaultFontSizeChanged();
+  void defaultFontChanged();
+  void defaultMonospaceFontSizeChanged();
+  void defaultMonospaceFontChanged();
+};
+
+#endif

--- a/src/app/TheoIDE/Persistence/systemfontconfiguration.cpp
+++ b/src/app/TheoIDE/Persistence/systemfontconfiguration.cpp
@@ -1,0 +1,25 @@
+#include "include/systemfontconfiguration.hpp"
+
+#include <qfontdatabase.h>
+
+SystemFontConfiguraton::SystemFontConfiguraton(QObject* parent)
+    : QObject(parent) {}
+SystemFontConfiguraton::~SystemFontConfiguraton() {}
+
+QFont SystemFontConfiguraton::defaultFont() const {
+  return QFontDatabase::systemFont(QFontDatabase::GeneralFont);
+}
+
+int SystemFontConfiguraton::defaultFontSize() const {
+  return defaultFont().pointSize();
+}
+
+QFont SystemFontConfiguraton::defaultMonospaceFont() const {
+  QFont monospaceFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+  monospaceFont.setStyleHint(QFont::TypeWriter);
+  return monospaceFont;
+}
+
+int SystemFontConfiguraton::defaultMonospaceFontSize() const {
+  return defaultMonospaceFont().pointSize();
+}


### PR DESCRIPTION
For testing, the cached settings must be deleted first to see a difference.
- On Linux, the settings are stored in the `.config/Theo IDE Development Team` directory
- On Windows the settings may be stored in the registry
- On MacOS the settings are stored in an XML File somewhere
- On Android, the settings and cache may deleted by simply deleting the application data in the settings
- On iOS, I have no clue 